### PR TITLE
Fix Bookcreator and Rename page plugins

### DIFF
--- a/main.php
+++ b/main.php
@@ -190,8 +190,9 @@ $showSidebar = page_findnearest($conf['sidebar']) && ($ACT == 'show');
                             <?php
                             $menu_items = (new \dokuwiki\Menu\PageMenu())->getItems();
                             foreach($menu_items as $item) {
+                                $attr = buildAttributes($item->getLinkAttributes('page-menu__link '));
                                 echo '<li>'
-                                    .'<a class="page-menu__link" href="'.$item->getLink().'" title="'.$item->getTitle().'">'
+                                    .'<a '.$attr.'>'
                                     .'<i class="">'.inlineSVG($item->getSvg()).'</i>'
                                     . '<span class="a11y">'.$item->getLabel().'</span>'
                                     . '</a></li>';


### PR DESCRIPTION
Bookcreator relies on "plugin_bookcreator__addtobook" class into "a" link to work. It's added by default by "<?php echo (new \dokuwiki\Menu\PageMenu())->getListItems(); ?>" function, but as Argon Alt builds a custom menu, it's not appending this class automatically to the "a" link and the bookcreator link doesn't work. It also fix compatibility issues with other plugins that relies on classes to properly function, as "Rename page" plugin.