### PR TITLE
Fix Bookcreator, Delete and Rename page plugins

### DIFF
--- a/main.php
+++ b/main.php
@@ -186,17 +186,22 @@ $showSidebar = page_findnearest($conf['sidebar']) && ($ACT == 'show');
 						</nav>
 
                         <!-- Page Menu -->
-                        <div class="argon-doku-page-menu">
-                            <?php
-                            $menu_items = (new \dokuwiki\Menu\PageMenu())->getItems();
-                            foreach($menu_items as $item) {
-                                echo '<li>'
-                                    .'<a class="page-menu__link" href="'.$item->getLink().'" title="'.$item->getTitle().'">'
-                                    .'<i class="">'.inlineSVG($item->getSvg()).'</i>'
-                                    . '<span class="a11y">'.$item->getLabel().'</span>'
-                                    . '</a></li>';
-                            }
-                            ?>
+                        <div id="dokuwiki__pagetools">
+                            <div class="argon-doku-page-menu tools">
+                                <ul>
+                                    <?php
+                                        $menu_items = (new \dokuwiki\Menu\PageMenu())->getItems();
+                                        foreach($menu_items as $item) {
+                                            $attr = buildAttributes($item->getLinkAttributes(false));
+                                            echo '<li class="'.$item->getType().'">'
+                                            .'<a '.$attr.'>'
+                                            .'<i class="">'.inlineSVG($item->getSvg()).'</i>'
+                                            . '<span class="a11y">'.$item->getLabel().'</span>'
+                                            . '</a></li>';
+                                        }
+                                    ?>
+                                </ul>
+                            </div>
                         </div>
 
                         <!-- Floating Top Button -->


### PR DESCRIPTION
Bookcreator relies on "plugin_bookcreator__addtobook" class into "a" link to work. It's added by default by "getListItems(); ?>" function, but as Argon Alt builds a custom menu, it's not appending this class automatically to the "a" link and the bookcreator link doesn't work. It also fix compatibility issues with other plugins that relies on classes to properly function, as "Delete page" and "Rename page" plugins.